### PR TITLE
Run mod on client-side only

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -15,7 +15,7 @@
     },
     "license": "MIT",
     "icon": "assets/e4mc_minecraft/icon.png",
-    "environment": "*",
+    "environment": "client",
     "entrypoints": {
         "main": [
             {


### PR DESCRIPTION
This mod only needs to run on the physical client. The mod's code will still be executed on the logical server. There is no need to run this on the dedicated server (physical server).

If you don't know the terminology here, this explains it:
https://fabricmc.net/wiki/tutorial:side